### PR TITLE
Refactor to use pandas.read_html

### DIFF
--- a/examples/notebook.ipynb
+++ b/examples/notebook.ipynb
@@ -34,7 +34,7 @@
     "\n",
     "## Read a simple HTML table\n",
     "\n",
-    "Read data from the first `<table>` element, from a local file path or web URL:"
+    "Read data from `<table>` element(s), from a local file path or web URL:"
    ],
    "cell_type": "markdown",
    "metadata": {}
@@ -92,9 +92,9 @@
   },
   {
    "source": [
-    "## Use a custom table selector\n",
+    "## Use `pandas.read_html` kwargs\n",
     "\n",
-    "Optionally use a CSS-style selector for more control over the source table:"
+    "Optionally pass through kwargs for more control over reading the source table(s):"
    ],
    "cell_type": "markdown",
    "metadata": {}
@@ -105,7 +105,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "src = HtmlTableSource(\"document.html\", selector=\"#data\")"
+    "src = HtmlTableSource(\"document.html\", attrs={\"id\": \"data\"})"
    ]
   },
   {
@@ -126,11 +126,11 @@
      "output_type": "execute_result",
      "data": {
       "text/plain": [
-       "  Column1 Column2 Column3           Column4\n",
-       "0      11    R1C2   False  2021-04-03 12:23\n",
-       "1      22    R2C2    True  2021-03-30 08:39\n",
-       "2      33    R3C2   False  2021-04-02 18:17\n",
-       "3      44    R4C2    True  2021-07-09 01:23"
+       "   Column1 Column2  Column3           Column4\n",
+       "0       11    R1C2    False  2021-04-03 12:23\n",
+       "1       22    R2C2     True  2021-03-30 08:39\n",
+       "2       33    R3C2    False  2021-04-02 18:17\n",
+       "3       44    R4C2     True  2021-07-09 01:23"
       ],
       "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>Column1</th>\n      <th>Column2</th>\n      <th>Column3</th>\n      <th>Column4</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>11</td>\n      <td>R1C2</td>\n      <td>False</td>\n      <td>2021-04-03 12:23</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>22</td>\n      <td>R2C2</td>\n      <td>True</td>\n      <td>2021-03-30 08:39</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>33</td>\n      <td>R3C2</td>\n      <td>False</td>\n      <td>2021-04-02 18:17</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>44</td>\n      <td>R4C2</td>\n      <td>True</td>\n      <td>2021-07-09 01:23</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
      },
@@ -267,7 +267,7 @@
      "output_type": "stream",
      "name": "stdout",
      "text": [
-      "<class 'pandas.core.frame.DataFrame'>\nRangeIndex: 185 entries, 0 to 184\nData columns (total 28 columns):\n #   Column            Non-Null Count  Dtype  \n---  ------            --------------  -----  \n 0   STATION           185 non-null    int64  \n 1   DATE              185 non-null    object \n 2   LATITUDE          185 non-null    float64\n 3   LONGITUDE         185 non-null    float64\n 4   ELEVATION         185 non-null    float64\n 5   NAME              185 non-null    object \n 6   TEMP              185 non-null    float64\n 7   TEMP_ATTRIBUTES   185 non-null    int64  \n 8   DEWP              185 non-null    float64\n 9   DEWP_ATTRIBUTES   185 non-null    int64  \n 10  SLP               185 non-null    float64\n 11  SLP_ATTRIBUTES    185 non-null    int64  \n 12  STP               185 non-null    float64\n 13  STP_ATTRIBUTES    185 non-null    int64  \n 14  VISIB             185 non-null    float64\n 15  VISIB_ATTRIBUTES  185 non-null    int64  \n 16  WDSP              185 non-null    float64\n 17  WDSP_ATTRIBUTES   185 non-null    int64  \n 18  MXSPD             185 non-null    float64\n 19  GUST              185 non-null    float64\n 20  MAX               185 non-null    float64\n 21  MAX_ATTRIBUTES    185 non-null    object \n 22  MIN               185 non-null    float64\n 23  MIN_ATTRIBUTES    185 non-null    object \n 24  PRCP              185 non-null    float64\n 25  PRCP_ATTRIBUTES   185 non-null    object \n 26  SNDP              185 non-null    float64\n 27  FRSHTT            185 non-null    int64  \ndtypes: float64(15), int64(8), object(5)\nmemory usage: 40.6+ KB\n"
+      "<class 'pandas.core.frame.DataFrame'>\nRangeIndex: 188 entries, 0 to 187\nData columns (total 28 columns):\n #   Column            Non-Null Count  Dtype  \n---  ------            --------------  -----  \n 0   STATION           188 non-null    int64  \n 1   DATE              188 non-null    object \n 2   LATITUDE          188 non-null    float64\n 3   LONGITUDE         188 non-null    float64\n 4   ELEVATION         188 non-null    float64\n 5   NAME              188 non-null    object \n 6   TEMP              188 non-null    float64\n 7   TEMP_ATTRIBUTES   188 non-null    int64  \n 8   DEWP              188 non-null    float64\n 9   DEWP_ATTRIBUTES   188 non-null    int64  \n 10  SLP               188 non-null    float64\n 11  SLP_ATTRIBUTES    188 non-null    int64  \n 12  STP               188 non-null    float64\n 13  STP_ATTRIBUTES    188 non-null    int64  \n 14  VISIB             188 non-null    float64\n 15  VISIB_ATTRIBUTES  188 non-null    int64  \n 16  WDSP              188 non-null    float64\n 17  WDSP_ATTRIBUTES   188 non-null    int64  \n 18  MXSPD             188 non-null    float64\n 19  GUST              188 non-null    float64\n 20  MAX               188 non-null    float64\n 21  MAX_ATTRIBUTES    188 non-null    object \n 22  MIN               188 non-null    float64\n 23  MIN_ATTRIBUTES    188 non-null    object \n 24  PRCP              188 non-null    float64\n 25  PRCP_ATTRIBUTES   188 non-null    object \n 26  SNDP              188 non-null    float64\n 27  FRSHTT            188 non-null    int64  \ndtypes: float64(15), int64(8), object(5)\nmemory usage: 41.2+ KB\n"
      ]
     }
    ],

--- a/intake_html_table/catalog.py
+++ b/intake_html_table/catalog.py
@@ -1,5 +1,12 @@
+from collections import namedtuple
+
 from intake.catalog.base import Catalog
 from intake.catalog.local import LocalCatalogEntry
+
+import numpy as np
+
+
+Record = namedtuple("Record", ("name", "modified", "size", "description", "is_directory", "full_path"))
 
 
 class ApacheDirectoryCatalog(Catalog):
@@ -20,7 +27,7 @@ class ApacheDirectoryCatalog(Catalog):
 
     name = "apache_dir"
     version = "0.0.1"
-    columns = {"Name": "object", "Last modified": "datetime64", "Size": "string", "Description": "string"}
+    columns = {"Name": "string", "Last modified": "datetime64", "Size": "float64", "Description": "string"}
 
     def __init__(self, urlpath, csv_kwargs={}, **kwargs):
         self.dataframe = None
@@ -29,44 +36,98 @@ class ApacheDirectoryCatalog(Catalog):
         self.description = f"Apache server directory <{urlpath}>"
         super(ApacheDirectoryCatalog, self).__init__(**kwargs)
 
+    def _close(self):
+        self.dataframe = None
+        return super()._close()
+
+    def _load(self):
+        from intake_html_table import HtmlTableSource
+
+        self._entries = {}
+
+        # read and remove rows with all null values (like table separators)
+        df = HtmlTableSource(self.urlpath).read().dropna(how="all")
+
+        # fixup sizes
+        df["Size"] = df["Size"].apply(self._expand_size)
+
+        # convert to known dtypes
+        self.dataframe = df.astype(self.columns)
+
+        # add a catalog entry for each row
+        self.dataframe.apply(self._add_entry, axis=1)
+
+    def _expand_size(self, size):
+        """
+        Expand a value from the Size column from str -> float
+
+        e.g. `"3.3K"` -> `3300.0`
+        """
+        sizes = {"K": 1000, "M": 1000000, "G": 1000000000}
+
+        try:
+            return float(size)
+        except ValueError:
+            for alpha, mult in sizes.items():
+                if size.endswith(alpha):
+                    return float(size.rstrip(alpha)) * mult
+            else:
+                return np.nan
+
+    def _add_entry(self, row):
+        """
+        Add catalog entries to this catalog for each row. Subdirectory entries
+        are handled separately from file entries.
+        """
+        record = self._process_row(row)
+
+        if record.is_directory:
+            e = self._subdir_entry(record.name, record.full_path)
+        else:
+            e = self._file_entry(record.name, record.full_path)
+
+        self._entries[e.name] = e
+
     def _process_row(self, row):
         """
-        Parse a single table row from an Apache Server directory page table.
-        Return a record like:
+        Parse a single table row (as a named tuple) from an Apache Server directory page table.
+
+        Return a named tuple:
 
         ```python
-        {
-            "name": "string",
-            "modified": "datetime64",
-            "size": "int64",
-            "description": "string",
-            "is_directory": "boolean",
-            "full_path": "string"
-        }
+        (
+            name="string",
+            modified="string",
+            size="float64",
+            description="string",
+            is_directory="boolean",
+            full_path="string"
+        )
         ```
         """
-        anchor = row.Name
-
-        if not anchor:
-            return {}
-
-        path = anchor.href
+        path = row.Name
         full_path = path if path.startswith(self.urlpath) else f"{self.urlpath}/{path}"
         name = path.replace(self.urlpath, "").rstrip("/")
-        parent = anchor.text.lower() == "parent directory"
+        parent = row.Name.lower() == "parent directory"
         parent_dir = self.urlpath.rstrip(path)[: self.urlpath.rstrip(path).rindex("/")] + "/" if parent else None
         directory = path.endswith("/")
 
-        return {
-            "name": "parent" if parent else name,
-            "modified": row._2,
-            "size": row.Size.replace("-", ""),
-            "description": row.Description,
-            "is_directory": directory,
-            "full_path": parent_dir if parent else full_path,
-        }
+        return Record(
+            "parent" if parent else name,
+            row["Last modified"],
+            row.Size,
+            row.Description,
+            directory,
+            parent_dir if parent else full_path,
+        )
 
     def _file_entry(self, name, urlpath):
+        """
+        Create a `LocalCatalogEntry` for a file.
+
+        `.csv` files are handled by the `csv` driver;
+        other file types are handled by the `textfiles` driver
+        """
         driver = "csv" if urlpath.find(".csv") > -1 else "textfiles"
         description = f"Apache server file <{urlpath}>"
         args = {"urlpath": urlpath}
@@ -77,6 +138,11 @@ class ApacheDirectoryCatalog(Catalog):
         return LocalCatalogEntry(name, description, driver, True, args, getenv=False, getshell=False, catalog=self)
 
     def _subdir_entry(self, path, urlpath):
+        """
+        Create a `LocalCatalogEntry` for a subdirectory.
+
+        Use the `ApacheDirectoryCatalog` driver to create a recursive hierarchy.
+        """
         description = f"Apache Server directory <{urlpath}>"
         args = {"urlpath": urlpath}
         driver = ApacheDirectoryCatalog.name
@@ -87,26 +153,6 @@ class ApacheDirectoryCatalog(Catalog):
         e.container = "catalog"
 
         return e
-
-    def _load(self):
-        from intake_html_table import HtmlTableSource
-
-        self._entries = {}
-        self.dataframe = HtmlTableSource(self.urlpath, columns=list(self.columns.keys())).read().astype(self.columns)
-
-        for row in self.dataframe.itertuples():
-            record = self._process_row(row)
-
-            if record["is_directory"]:
-                e = self._subdir_entry(record["name"], record["full_path"])
-            else:
-                e = self._file_entry(record["name"], record["full_path"])
-
-            self._entries[e.name] = e
-
-    def _close(self):
-        self.dataframe = None
-        return super()._close()
 
     def read(self):
         if self.dataframe is None:

--- a/intake_html_table/source.py
+++ b/intake_html_table/source.py
@@ -1,208 +1,54 @@
 from intake.source import base
 
+import pandas as pd
 
-class BaseHtmlTableSource(base.DataSource):
+
+class HtmlTableSource(base.DataSource):
     """
-    Base class for an in-memory representation of data in an HTML table. This class cannot be used directly.
+    HTML to dataframes reader. Tables are read and stored in-memory.
 
-    Inherit from this class and implement `_find_rows(self, table)` and `_get_record(self, tr)` for new HTML table sources.
+    Partition by individual table(s) read from source.
 
-    Parameters
-    ----------
-    urlpath: str
-        Full path to resource containing an HTML table
-    selector: str
-        CSS-style selector for the table element. Default: 'table'
-    columns: list or None
-        List of expected column names. Default: None
+    Forwards extra keyword arguments to `pandas.read_html()`.
     """
 
+    name = "html_table"
+    version = "0.0.1"
     container = "dataframe"
     partition_access = True
 
-    def __init__(self, urlpath, selector="table", columns=None, **kwargs):
-        self.urlpath = urlpath
-        self.selector = selector
-        self.columns = columns
+    def __init__(self, io, storage_options=None, metadata=None, **kwargs):
+        self.io = io
+        self.dataframes = None
+        self.kwargs = kwargs
 
-        self.dataframe = None
-        self.soup = None
-        self.table = None
-
-        super(BaseHtmlTableSource, self).__init__(**kwargs)
+        super(HtmlTableSource, self).__init__(storage_options=storage_options, metadata=metadata)
 
     def _close(self):
-        self.dataframe = None
-        self.soup = None
-        self.table = None
+        self.dataframes = None
 
     def _load(self):
         """
         Initialize the DataFrame.
         """
-        import bs4
-        import fsspec
-
-        of = fsspec.open(self.urlpath, **self.storage_options)
-        with of as f:
-            self.soup = bs4.BeautifulSoup(f.read(), "html.parser")
-
-        table = self.soup.select_one(self.selector)
-        if not table:
-            raise RuntimeError(f"Could not find <table> matching selector '{self.selector}' at: {self.urlpath}")
-
-        self._check_header(table)
-        self.table = table
-        self.dataframe = self._get_dataframe(table)
-
-    def _check_header(self, table):
-        """
-        Verifies the expected table header row. Throws RuntimeError for invalid tables.
-        """
-        if self.columns:
-            header = table.find("tr")
-            cells = header.find_all(["th", "td"], recursive=False) if header else []
-
-            if len(cells) != len(self.columns):
-                raise RuntimeError(f"<table> with unexpected header row at: {self.urlpath}")
-
-            for i in range(len(self.columns)):
-                col = cells[i].get_text()
-                if col != self.columns[i]:
-                    raise RuntimeError(f"<table> column[{i}] got '{col}', expected '{self.columns[i]}' at: {self.urlpath}")
-
-    def _find_rows(self, table):
-        """
-        Get a list of <tr> from a beautifulsoup4 tag representing a <table>.
-        """
-        raise NotImplementedError("Implement this method in an inherited class.")
-
-    def _get_record(self, tr):
-        """
-        Create a python dict record from a beautifulsoup4 tag representing a <tr>.
-        """
-        raise NotImplementedError("Implement this method in an inherited class.")
-
-    def _get_dataframe(self, table):
-        """
-        Produce the DataFrame from records in table.
-        """
-        from pandas import DataFrame as df
-
-        record = self._get_record
-        rows = self._find_rows
-        dataframe = df.from_records
-
-        records = [record(tr) for tr in rows(table)]
-
-        return dataframe(records)
+        self.dataframes = pd.read_html(self.io, **self.kwargs)
 
     def _get_schema(self):
-        if self.dataframe is None:
+        if self.dataframes is None:
             self._load()
 
         return base.Schema(
-            datashape=None,
-            dtype=self.dataframe.dtypes,
-            shape=self.dataframe.shape,
-            npartitions=1,
+            dtype=None,
+            shape=(None,),
+            npartitions=len(self.dataframes),
             extra_metadata={},
         )
 
     def _get_partition(self, i):
-        self._get_schema()
-        return self.dataframe
+        self._load_metadata()
+        return self.dataframes[i]
 
     def read(self):
-        self._get_schema()
-        return self.dataframe
-
-
-class HtmlTableSource(BaseHtmlTableSource):
-    """
-    HTML table to dataframe reader (no partitioning).
-
-    Caches entire dataframe in memory.
-
-    Parameters
-    ----------
-    urlpath: str
-        Full path to resource containing an HTML table
-    infer_header: bool
-        True to infer a header from table when no columns are given. Default: True.
-    parse_anchors: bool
-        True to extract href and target from cells with anchors. Default: True.
-    selector: str
-        CSS-style selector for the table element. Default: 'table'
-    columns: list or None
-        List of expected column names. Default: None
-    """
-
-    name = "html_table"
-    version = "0.0.1"
-
-    def __init__(self, urlpath, infer_header=True, parse_anchors=True, selector="table", columns=None, **kwargs):
-        self.description = f"HTML table <{urlpath}>"
-        self.infer_header = infer_header
-        self.parse_anchors = parse_anchors
-        super().__init__(urlpath, selector=selector, columns=columns, **kwargs)
-
-    def _get_header(self):
-        """
-        Get the header row for this table.
-        """
-        if self.infer_header and not self.columns:
-            # try thead, fallback to first row in table
-            row = (self.table.find("thead") or self.table).find("tr")
-            header = [cell.get_text().strip() for cell in row.find_all(["th", "td"], recursive=False)] if row else None
-            self.columns = header
-        elif self.columns:
-            header = self.columns
-        else:
-            header = None
-        return header
-
-    def _find_rows(self, table):
-        """
-        Get top-level table rows with at least one data cell. When a header is defined, only get rows with matching data cells.
-        """
-        header = self._get_header()
-        source = self.table.find("tbody") or self.table
-
-        if header:
-
-            def filter(t):
-                return t.name == "tr" and len(t.find_all("td", recursive=False)) == len(header)
-
-        else:
-
-            def filter(t):
-                return t.name == "tr" and t.find_all("td", recursive=False)
-
-        return source.find_all(filter, recursive=False)
-
-    def _get_record(self, tr):
-        """
-        Convert the table row of data into a python dict.
-        """
-        header = self._get_header()
-        cells = tr.find_all("td", recursive=False)
-
-        def key(i):
-            return header[i] if header else str(i)
-
-        def value(i):
-            from collections import namedtuple
-
-            Anchor = namedtuple("anchor", ("text", "href", "target"))
-            cell = cells[i]
-            if self.parse_anchors and cell.find("a"):
-                a = cell.find("a")
-                return Anchor(a.get_text().strip(), a.get("href"), a.get("target"))
-            else:
-                return cell.get_text().strip()
-
-        if header is None or len(header) == len(cells):
-            return {key(i): value(i) for i in range(len(cells))}
-        else:
-            return None
+        self._load_metadata()
+        parts = [self.read_partition(i) for i in range(self.npartitions)]
+        return pd.concat(parts)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 aiohttp>=3.7.4
 beautifulsoup4>=4.9.3
-fsspec>=2021.6.1
 intake>=0.6.2
+lxml>=4.6.3
 msgpack>=1.0.2
 pandas>=1.3.0
 requests>=2.25.1


### PR DESCRIPTION
Greatly simplify `HtmlTableSource` by forwarding to [`pandas.read_html`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_html.html?highlight=read_html#pandas.read_html)

By and large, the public interface of the source remains unchanged. `HtmlTableSource.read()` produces:

* when the source HTML contains a single table, the same result as before, a single dataframe with headers inferred
* when the source HTML contains multiple tables, a concatenation of those tables into a single dataframe with a MultiIndex

The `selector` keyword argument for the class has been removed in favor of the `attr` keyword argument, forwarding to `pandas.read_html`.

The `columns` keyword argument has been removed, and this source no longer attempts to validate columns.
Instead push to the user as `pandas` does.