### PR TITLE
Remove coverage badge generation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,15 +19,3 @@ jobs:
         run: |
           coverage run -m pytest
           coverage report -m
-          coverage-badge -fqo tests/coverage.svg
-      - name: Update coverage
-        run: |
-          git config user.name "GitHub Actions"
-          git config user.email "actions@github.com"
-          git add tests/coverage.svg
-          timestamp=$(date -u)
-          git commit -m "chore(tests): update coverage ${timestamp}
-
-
-          on-behalf-of: @compilerla" || exit 0
-          git push

--- a/README.md
+++ b/README.md
@@ -63,9 +63,17 @@ coverage run -m pytest
 
 To view the `coverage` report with indicators for untested (missed) lines:
 
-```
+```bash
 coverage report -m
 ```
+
+To upate the README badge ![Test coverage percentage](tests/coverage.svg) from the latest test run:
+
+```bash
+coverage-badge -f -o tests/coverage.svg
+```
+
+The `-f` argument ensures the existing badge is overwritten.
 
 Tests also run via [GitHub Action](./.github/workflows/test.yml) on events against the `main` branch.
 


### PR DESCRIPTION
This creates a commit that doesn't trigger checks, rendering the PR unmergeable; see #9.

TODO: figure out how to auto-generate and update the coverage badge later.